### PR TITLE
Launch item color option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ favicon
 =======
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge)](https://github.com/hacs/integration)
 
-Change the gui page title, favicon, app icons, and and launch icon color of your Home Assistant instance
+Change the gui page title, favicon, app icons, and launch icon color of your Home Assistant instance
 
 ![browser](https://user-images.githubusercontent.com/1299821/62975860-ad283a80-be1b-11e9-836a-d58a1732fb21.png)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ favicon
 =======
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge)](https://github.com/hacs/integration)
 
-Change the gui page title, favicon and app icons of your Home Assistant instance
+Change the gui page title, favicon, app icons, and and launch icon color of your Home Assistant instance
 
 ![browser](https://user-images.githubusercontent.com/1299821/62975860-ad283a80-be1b-11e9-836a-d58a1732fb21.png)
 

--- a/custom_components/favicon/__init__.py
+++ b/custom_components/favicon/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.config_entries import ConfigEntry, ConfigType
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 
-from .const import CONF_ICON_PATH, CONF_TITLE, DOMAIN
+from .const import CONF_ICON_COLOR, CONF_ICON_PATH, CONF_KEYS, CONF_TITLE, DOMAIN
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -37,10 +37,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     conf = config.get(DOMAIN)
     if not conf:
         return True
-    if CONF_ICON_PATH in hass.data[DOMAIN]:
-        del hass.data[DOMAIN][CONF_ICON_PATH]
-    if CONF_TITLE in hass.data[DOMAIN]:
-        del hass.data[DOMAIN][CONF_TITLE]
+    for key in CONF_KEYS:
+        if key in hass.data[DOMAIN]:
+            del hass.data[DOMAIN][key]
     hass.data[DOMAIN].update(conf)
     return await apply_hooks(hass)
 
@@ -69,10 +68,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def _update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     _LOGGER.debug("[update_listener] Starting")
     conf = config_entry.options
-    if CONF_ICON_PATH in hass.data[DOMAIN]:
-        del hass.data[DOMAIN][CONF_ICON_PATH]
-    if CONF_TITLE in hass.data[DOMAIN]:
-        del hass.data[DOMAIN][CONF_TITLE]
+    for key in CONF_KEYS:
+        if key in hass.data[DOMAIN]:
+            del hass.data[DOMAIN][key]
     hass.data[DOMAIN].update(conf)
     return await apply_hooks(hass, dict(config_entry.data))
 
@@ -124,6 +122,7 @@ async def apply_hooks(hass: HomeAssistant, config_data: MutableMapping[str, Any]
         None, find_icons, hass, config_data.get(CONF_ICON_PATH, None)
     )
     title = config_data.get(CONF_TITLE, None)
+    launch_icon_color = config_data.get(CONF_ICON_COLOR, None)
     data = hass.data.get(DOMAIN, {})
 
     def _get_template(self):
@@ -162,6 +161,12 @@ async def apply_hooks(hass: HomeAssistant, config_data: MutableMapping[str, Any]
                         </script>
                     """,  # noqa: E501
                 )
+            if launch_icon_color:
+                text = text.replace(
+                    '<link rel="mask-icon" href="/static/icons/mask-icon.svg" color="#18bcf2">',
+                    f'<link rel="mask-icon" href="/static/icons/mask-icon.svg" color="{launch_icon_color}">',
+                )
+                text = text.replace('<path fill="#18BCF2" ', f'<path fill="{launch_icon_color}" ')
 
             return text
 

--- a/custom_components/favicon/__init__.py
+++ b/custom_components/favicon/__init__.py
@@ -161,12 +161,23 @@ async def apply_hooks(hass: HomeAssistant, config_data: MutableMapping[str, Any]
                         </script>
                     """,  # noqa: E501
                 )
+
             if launch_icon_color:
-                text = text.replace(
-                    '<link rel="mask-icon" href="/static/icons/mask-icon.svg" color="#18bcf2">',
-                    f'<link rel="mask-icon" href="/static/icons/mask-icon.svg" color="{launch_icon_color}">',
+                # Regex to match hex color codes (e.g., #18bcf2, #123ABC)
+                hex_color_pattern = r"#(?:[0-9a-fA-F]{6})"
+
+                text = re.sub(
+                    r'(<link rel="mask-icon" href="/static/icons/mask-icon\.svg" color=")'
+                    + hex_color_pattern
+                    + r'(">)',
+                    rf"\1{launch_icon_color}\2",
+                    text,
                 )
-                text = text.replace('<path fill="#18BCF2" ', f'<path fill="{launch_icon_color}" ')
+                text = re.sub(
+                    r'(<path fill=")' + hex_color_pattern + r'(")',
+                    rf"\1{launch_icon_color}\2",
+                    text,
+                )
 
             return text
 

--- a/custom_components/favicon/config_flow.py
+++ b/custom_components/favicon/config_flow.py
@@ -11,7 +11,15 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.core import callback
 
-from .const import CONF_ICON_PATH, CONF_TITLE, DEFAULT_ICON_PATH, DEFAULT_TITLE, DOMAIN
+from .const import (
+    CONF_ICON_COLOR,
+    CONF_ICON_PATH,
+    CONF_TITLE,
+    DEFAULT_ICON_COLOR,
+    DEFAULT_ICON_PATH,
+    DEFAULT_TITLE,
+    DOMAIN,
+)
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -39,6 +47,7 @@ def _get_schema(
         {
             vol.Required(CONF_TITLE, default=_get_default(CONF_TITLE)): str,
             vol.Required(CONF_ICON_PATH, default=_get_default(CONF_ICON_PATH)): str,
+            vol.Required(CONF_ICON_COLOR): str,  # TODO: Make color selector
         },
     )
 
@@ -59,6 +68,7 @@ class FaviconConfigFlow(ConfigFlow, domain=DOMAIN):
         input_defaults: MutableMapping[str, Any] = {
             CONF_TITLE: DEFAULT_TITLE,
             CONF_ICON_PATH: DEFAULT_ICON_PATH,
+            CONF_ICON_COLOR: DEFAULT_ICON_COLOR,
         }
 
         if user_input is not None:

--- a/custom_components/favicon/const.py
+++ b/custom_components/favicon/const.py
@@ -5,6 +5,10 @@ DOMAIN = "favicon"
 
 CONF_TITLE = "title"
 CONF_ICON_PATH = "icon_path"
+CONF_ICON_COLOR = "launch_icon_color"
+
+CONF_KEYS = [CONF_TITLE, CONF_ICON_PATH, CONF_ICON_COLOR]
 
 DEFAULT_TITLE = "Home Assistant"
 DEFAULT_ICON_PATH = "/local/favicons/"
+DEFAULT_ICON_COLOR = "#18BCF2"

--- a/custom_components/favicon/translations/en.json
+++ b/custom_components/favicon/translations/en.json
@@ -4,10 +4,11 @@
     "step": {
       "user": {
         "title": "Favicon changer",
-        "description": "Set the page title, and path to icons.",
+        "description": "Set the page title, path to icons, and launch icon color.",
         "data": {
           "title": "Page title",
-          "icon_path": "Icon path"
+          "icon_path": "Icon path",
+          "launch_icon_color": "Launch icon color"
         }
       }
     },
@@ -20,7 +21,8 @@
       "init": {
         "data": {
           "title": "Page title",
-          "icon_path": "Icon path"
+          "icon_path": "Icon path",
+          "launch_icon_color": "Launch icon color"
         }
       }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added ability to customize launch icon color in Home Assistant favicon integration.
	- Expanded configuration options for favicon customization.

- **Documentation**
	- Updated README to clarify available customization features.
	- Enhanced English translations to explain new color configuration option.

- **Improvements**
	- Implemented more flexible configuration key management.
	- Added support for color input in both RGB and hexadecimal formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->